### PR TITLE
Apply tar's extract workaround for bun on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,32 @@ jobs:
         run: pnpm typecheck
       - name: Run tests
         run: pnpm test
+
+      # Test on Bun that only happens on windows without Node.js installed
+      - if: ${{ matrix.os == 'windows-latest' }}
+        name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - if: ${{ matrix.os == 'windows-latest' }}
+        name: Remove Node.js binaries on Windows
+        run: |
+          # Get node path using where command (Windows equivalent of which)
+          $nodePath = where.exe node 2>$null
+          if ($nodePath) {
+            Write-Host "Found node at: $nodePath"
+            Remove-Item -Path $nodePath -Force
+            Write-Host "Removed node.exe"
+          }
+          # Check Node.js  are not accessible
+          try {
+            & node --version
+            throw "Node.js is still accessible"
+          } catch {
+            Write-Host "Node.js successfully removed"
+            exit 0
+          }
+        shell: pwsh
+      - if: ${{ matrix.os == 'windows-latest' }}
+        name: Run tests for Bun on Windows
+        run: bun run test:bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             Remove-Item -Path $nodePath -Force
             Write-Host "Removed node.exe"
           }
-          # Check Node.js  are not accessible
+          # Check Node.js are not accessible
           try {
             & node --version
             throw "Node.js is still accessible"

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "download"
   ],
   "scripts": {
-    "test": "node --test",
-    "test:bun": "bun test runtime/bun-windows.test.js",
+    "test": "node --test \"test/*.test.js\"",
+    "test:bun": "bun test \"test/bun-windows.spec.js\"",
     "lint": "prettier \"**/*.{js,ts,md}\" --check",
     "format": "prettier \"**/*.{js,ts,md}\" --write",
     "typecheck": "tsc"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "test": "node --test",
+    "test:bun": "bun test runtime/bun-windows.test.js",
     "lint": "prettier \"**/*.{js,ts,md}\" --check",
     "format": "prettier \"**/*.{js,ts,md}\" --write",
     "typecheck": "tsc"

--- a/runtime-test/bun-windows.test.js
+++ b/runtime-test/bun-windows.test.js
@@ -1,0 +1,41 @@
+// @ts-expect-error: TS doesn't know about the global Bun.
+import { it, describe, beforeEach, afterEach } from 'bun:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import fss from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { downloadTemplate } from '../src/download-template.js'
+
+// NOTE: This test for Bun on windows.
+
+const dumpDir = fileURLToPath(new URL('../test-dump/', import.meta.url))
+const cacheDir = path.join(dumpDir, 'cache')
+const downloadDir = path.join(dumpDir, 'download')
+
+// Remove dump dir so the tests are deterministic
+fss.rmSync(dumpDir, { recursive: true, force: true })
+
+describe('downloadTemplate', () => {
+  let originalXdgCacheHome = process.env.XDG_CACHE_HOME
+
+  beforeEach(async () => {
+    // Download cache in sibling directory for easy debugging
+    process.env.XDG_CACHE_HOME = cacheDir
+    await fs.rm(downloadDir, { recursive: true, force: true })
+  })
+
+  afterEach(() => {
+    process.env.XDG_CACHE_HOME = originalXdgCacheHome
+  })
+
+  it('downloads a template', async () => {
+    const targetDir = path.join(downloadDir, 'from-github')
+    const result = await downloadTemplate('unjs/template', {
+      dir: targetDir,
+    })
+
+    assert.ok(fss.existsSync(targetDir))
+    assert.ok(fss.existsSync(path.join(targetDir, 'README.md')))
+  })
+})

--- a/src/utils.js
+++ b/src/utils.js
@@ -159,6 +159,7 @@ export async function extract(tarPath, extractPath, subdir) {
   const needWorkaround =
     // @ts-expect-error: TS doesn't know about the global Bun.
     typeof Bun !== 'undefined' && process.platform === 'win32'
+  const originalFakePlatform = process.env.__FAKE_PLATFORM__
 
   if (needWorkaround) {
     process.env.__FAKE_PLATFORM__ = 'linux'
@@ -169,7 +170,11 @@ export async function extract(tarPath, extractPath, subdir) {
 
   if (needWorkaround) {
     // Cleaning up the fake platform.
-    delete process.env.__FAKE_PLATFORM__
+    if (originalFakePlatform != null) {
+      process.env.__FAKE_PLATFORM__ = originalFakePlatform
+    } else {
+      delete process.env.__FAKE_PLATFORM__
+    }
   }
 
   // NOTE: using tar@6 because v7 is HUGE

--- a/test/bun-windows.spec.js
+++ b/test/bun-windows.spec.js
@@ -31,7 +31,7 @@ describe('downloadTemplate', () => {
 
   it('downloads a template', async () => {
     const targetDir = path.join(downloadDir, 'from-github')
-    const result = await downloadTemplate('unjs/template', {
+    await downloadTemplate('unjs/template', {
       dir: targetDir,
     })
 

--- a/test/download-template.test.js
+++ b/test/download-template.test.js
@@ -80,14 +80,14 @@ describe('downloadTemplate', () => {
 
   it('downloads a template in subdir', async () => {
     const targetDir = path.join(downloadDir, 'subdir')
-    const result = await downloadTemplate('unjs/template/playground', {
+    const result = await downloadTemplate('unjs/template/test', {
       dir: targetDir,
     })
 
     assert.ok(fss.existsSync(targetDir))
-    assert.ok(fss.existsSync(path.join(targetDir, 'index.ts')))
+    assert.ok(fss.existsSync(path.join(targetDir, 'index.test.ts')))
     assert.equal(result.info.name, 'unjs-template')
-    assert.equal(result.source, 'unjs/template/playground')
+    assert.equal(result.source, 'unjs/template/test')
   })
 
   // This relies on previous tests already caching unjs/template (github)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,6 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true
   },
-  "include": ["src", "test"],
+  "include": ["src", "test", "runtime-test"],
   "exclude": ["node_modules", "test-dump"]
 }


### PR DESCRIPTION
closes #3

Apply the patch according to unjs/giget#180, and add a runtime test to check the operation.
It's a hacky CI test, so if you don't need the runtime test, we can remove it.