### PR TITLE
fix: typo

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -22,11 +22,11 @@ export function getProvider(input, providerName, providers) {
   providerName ||= 'github'
 
   let source = input
-  const sourceProvierMatch = input.match(sourceProtoRe)
-  if (sourceProvierMatch) {
-    providerName = sourceProvierMatch[1]
+  const sourceProviderMatch = input.match(sourceProtoRe)
+  if (sourceProviderMatch) {
+    providerName = sourceProviderMatch[1]
     if (providerName !== 'http' && providerName !== 'https') {
-      source = input.slice(sourceProvierMatch[0].length)
+      source = input.slice(sourceProviderMatch[0].length)
     }
   }
 


### PR DESCRIPTION
This pull request includes a small fix to the `getProvider` function in the `src/utils.js` file. The change corrects a typo in the variable name from `sourceProvierMatch` to `sourceProviderMatch` to ensure consistent naming and avoid potential errors.