### PR TITLE
Switch to modern-tar

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A JavaScript API to download a template from a git repository or URL. The code is largely based on [giget](https://github.com/unjs/giget) (and includes its license), but with the below main differences:
 
 - Only the JavaScript API. The CLI and unrelated APIs are stripped off.
-- Reduced dependencies to only 1 ([tar](https://github.com/isaacs/node-tar)).
+- Reduced dependencies to only 1 ([modern-tar](https://github.com/ayuhito/modern-tar)).
 - Modified API interface (reduce input and output surface).
 - Removed custom registries and JSON template support.
 - Removed `GIGET_` special environment variables support.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "packageManager": "pnpm@10.12.3",
   "dependencies": {
-    "tar": "^7.4.3"
+    "modern-tar": "^0.3.4"
   },
   "devDependencies": {
     "@types/node": "^22.15.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      tar:
-        specifier: ^7.4.3
-        version: 7.4.3
+      modern-tar:
+        specifier: ^0.3.4
+        version: 0.3.4
     devDependencies:
       '@types/node':
         specifier: ^22.15.33
@@ -24,38 +24,17 @@ importers:
 
 packages:
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@types/node@22.15.33':
     resolution: {integrity: sha512-wzoocdnnpSxZ+6CjW4ADCK1jVmd1S/J3ArNWfn8FDDQtRm8dkDg7TA+mvek2wNrfCgwuZxqEOiB9B1XCJ6+dbw==}
 
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
-
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.0.2:
-    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
-    engines: {node: '>= 18'}
-
-  mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
-    engines: {node: '>=10'}
-    hasBin: true
+  modern-tar@0.3.4:
+    resolution: {integrity: sha512-BBQDjmhLJekFGhcG0C44sAl5/78UmqWa9ZJ2YqCj00NVixH3U8VjryzLIokKap0mo/pmIIJJXjZhM6bizi/6Pw==}
+    engines: {node: '>=18.0.0'}
 
   prettier@3.6.0:
     resolution: {integrity: sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==}
     engines: {node: '>=14'}
     hasBin: true
-
-  tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
-    engines: {node: '>=18'}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -65,43 +44,16 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
-
 snapshots:
-
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.2
 
   '@types/node@22.15.33':
     dependencies:
       undici-types: 6.21.0
 
-  chownr@3.0.0: {}
-
-  minipass@7.1.2: {}
-
-  minizlib@3.0.2:
-    dependencies:
-      minipass: 7.1.2
-
-  mkdirp@3.0.1: {}
+  modern-tar@0.3.4: {}
 
   prettier@3.6.0: {}
-
-  tar@7.4.3:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.0.2
-      mkdirp: 3.0.1
-      yallist: 5.0.0
 
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
-
-  yallist@5.0.0: {}

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,37 +157,35 @@ export async function extract(tarPath, extractPath, subdir) {
 
   const readStream = fss.createReadStream(tarPath)
   const unpackStream = unpackTar(extractPath, {
-    filter: (entry) => {
-      const path = entry.name.split('/').slice(1).join('/');
+    filter(entry) {
+      const path = entry.name.split('/').slice(1).join('/')
 
       // Skip the root directory
       if (path === '') {
-        return false;
+        return false
       }
 
       if (!subdir) {
-        return true;
+        return true
       }
 
       if (path.startsWith(subdir)) {
-        subdirFound = true;
-        return true;
+        subdirFound = true
+        return true
       } else {
-        return false;
+        return false
       }
     },
-
-    map: (entry) => {
-      let path = entry.name.split('/').slice(1).join('/');
+    map(entry) {
+      let path = entry.name.split('/').slice(1).join('/')
 
       if (subdir) {
-        path = path.slice(subdir.length);
+        path = path.slice(subdir.length)
       }
 
-      entry.name = path;
-      return entry;
+      entry.name = path
+      return entry
     },
-
   })
 
   await pipeline(readStream, createGunzip(), unpackStream)


### PR DESCRIPTION
If there is any appetite to reduce the dependency count even more, may I suggest giving [`modern-tar`](https://github.com/ayuhito/modern-tar) a go? It will at least reduce the 2MB unpacked size of `tar` with something much much smaller. 

We also don't need the Bun workaround since we don't implement that Windows specific optimization `tar` uses that Bun doesn't support.

<img width="1554" height="822" alt="image" src="https://github.com/user-attachments/assets/0acbe99a-d400-43f1-9b05-57d1c9e0f6ae" />

Reference: https://npmgraph.js.org/?q=%40bluwy%2Fgiget-core

Please let me know if there any concerns!
