### PR TITLE
Revert "Switch to modern-tar"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A JavaScript API to download a template from a git repository or URL. The code is largely based on [giget](https://github.com/unjs/giget) (and includes its license), but with the below main differences:
 
 - Only the JavaScript API. The CLI and unrelated APIs are stripped off.
-- Reduced dependencies to only 1 ([modern-tar](https://github.com/ayuhito/modern-tar)).
+- Reduced dependencies to only 1 ([tar](https://github.com/isaacs/node-tar)).
 - Modified API interface (reduce input and output surface).
 - Removed custom registries and JSON template support.
 - Removed `GIGET_` special environment variables support.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "packageManager": "pnpm@10.12.3",
   "dependencies": {
-    "modern-tar": "^0.3.4"
+    "tar": "^7.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.15.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      modern-tar:
-        specifier: ^0.3.4
-        version: 0.3.4
+      tar:
+        specifier: ^7.4.3
+        version: 7.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.15.33
@@ -24,17 +24,38 @@ importers:
 
 packages:
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@types/node@22.15.33':
     resolution: {integrity: sha512-wzoocdnnpSxZ+6CjW4ADCK1jVmd1S/J3ArNWfn8FDDQtRm8dkDg7TA+mvek2wNrfCgwuZxqEOiB9B1XCJ6+dbw==}
 
-  modern-tar@0.3.4:
-    resolution: {integrity: sha512-BBQDjmhLJekFGhcG0C44sAl5/78UmqWa9ZJ2YqCj00NVixH3U8VjryzLIokKap0mo/pmIIJJXjZhM6bizi/6Pw==}
-    engines: {node: '>=18.0.0'}
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.0.2:
+    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+    engines: {node: '>= 18'}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   prettier@3.6.0:
     resolution: {integrity: sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==}
     engines: {node: '>=14'}
     hasBin: true
+
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -44,16 +65,43 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
 snapshots:
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
 
   '@types/node@22.15.33':
     dependencies:
       undici-types: 6.21.0
 
-  modern-tar@0.3.4: {}
+  chownr@3.0.0: {}
+
+  minipass@7.1.2: {}
+
+  minizlib@3.0.2:
+    dependencies:
+      minipass: 7.1.2
+
+  mkdirp@3.0.1: {}
 
   prettier@3.6.0: {}
+
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.2
+      mkdirp: 3.0.1
+      yallist: 5.0.0
 
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
+
+  yallist@5.0.0: {}

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,9 +2,8 @@ import fs from 'node:fs/promises'
 import fss from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { pipeline } from 'node:stream/promises'
-import { createGunzip } from 'node:zlib'
-import { unpackTar } from 'modern-tar/fs'
+import { pipeline } from 'node:stream'
+import { promisify } from 'node:util'
 import { DownloadFailedError, SubdirNotFoundError } from './errors.js'
 import { providers as builtinProviders } from './providers.js'
 
@@ -77,7 +76,7 @@ export async function download(url, filePath, options = {}) {
 
   await fs.mkdir(path.dirname(filePath), { recursive: true })
   const stream = fss.createWriteStream(filePath)
-  await pipeline(response.body, stream)
+  await promisify(pipeline)(response.body, stream)
 
   await fs.writeFile(infoPath, JSON.stringify(info), 'utf8')
 }
@@ -155,40 +154,51 @@ export async function extract(tarPath, extractPath, subdir) {
   // Create an empty directory here to make tar happy
   await fs.mkdir(extractPath, { recursive: true })
 
-  const readStream = fss.createReadStream(tarPath)
-  const unpackStream = unpackTar(extractPath, {
-    filter(entry) {
-      const path = entry.name.split('/').slice(1).join('/')
+  // Workaround for Bun bug on Windows
+  // See https://github.com/oven-sh/bun/issues/12696
+  const needWorkaround =
+    // @ts-expect-error: TS doesn't know about the global Bun.
+    typeof Bun !== 'undefined' && process.platform === 'win32'
+  const originalFakePlatform = process.env.__FAKE_PLATFORM__
 
-      // Skip the root directory
-      if (path === '') {
-        return false
-      }
+  if (needWorkaround) {
+    process.env.__FAKE_PLATFORM__ = 'linux'
+  }
 
-      if (!subdir) {
-        return true
-      }
+  // We dynamically import `tar` to make sure the platform is faked if needed.
+  const { extract: _extract } = await import('tar')
 
-      if (path.startsWith(subdir)) {
-        subdirFound = true
-        return true
-      } else {
-        return false
-      }
-    },
-    map(entry) {
-      let path = entry.name.split('/').slice(1).join('/')
+  if (needWorkaround) {
+    // Cleaning up the fake platform.
+    if (originalFakePlatform != null) {
+      process.env.__FAKE_PLATFORM__ = originalFakePlatform
+    } else {
+      delete process.env.__FAKE_PLATFORM__
+    }
+  }
 
+  await _extract({
+    file: tarPath,
+    cwd: extractPath,
+    // `chmod` and `processUmask` are set for compatibility with v6 behaviour,
+    // however it also seems useful to enable these anyways in case the downloaded
+    // templates have executable bash scripts or similar.
+    chmod: true,
+    processUmask: 0o22,
+    onReadEntry(entry) {
+      entry.path = entry.path.split('/').splice(1).join('/')
       if (subdir) {
-        path = path.slice(subdir.length)
+        if (entry.path.startsWith(subdir)) {
+          // Rewrite path
+          entry.path = entry.path.slice(subdir.length - 1)
+          subdirFound = true
+        } else {
+          // Skip
+          entry.path = ''
+        }
       }
-
-      entry.name = path
-      return entry
     },
   })
-
-  await pipeline(readStream, createGunzip(), unpackStream)
 
   if (subdir && !subdirFound) {
     // Clean up as it should be empty


### PR DESCRIPTION
Reverts bluwy/giget-core#7

Let's revert this change in lieu of https://github.com/withastro/astro/issues/14463

Seems like `node:zlib` is throwing due to some truncated `gzip` errors, that then propagate to `modern-tar` as `TransformStream has been terminated`. 

I believe `tar` swallows these errors with `minizlib` and handles this gracefully in some way, but this needs much more research and cannot be resolved in a timely manner yet.