### PR TITLE
Switch to modern-tar again

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A JavaScript API to download a template from a git repository or URL. The code is largely based on [giget](https://github.com/unjs/giget) (and includes its license), but with the below main differences:
 
 - Only the JavaScript API. The CLI and unrelated APIs are stripped off.
-- Reduced dependencies to only 1 ([tar](https://github.com/isaacs/node-tar)).
+- Reduced dependencies to only 1 ([modern-tar](https://github.com/ayuhito/modern-tar)).
 - Modified API interface (reduce input and output surface).
 - Removed custom registries and JSON template support.
 - Removed `GIGET_` special environment variables support.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "packageManager": "pnpm@10.12.3",
   "dependencies": {
-    "tar": "^7.4.3"
+    "modern-tar": "^0.3.5"
   },
   "devDependencies": {
     "@types/node": "^22.15.33",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      tar:
-        specifier: ^7.4.3
-        version: 7.4.3
+      modern-tar:
+        specifier: ^0.3.5
+        version: 0.3.5
     devDependencies:
       '@types/node':
         specifier: ^22.15.33
@@ -24,38 +24,17 @@ importers:
 
 packages:
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
   '@types/node@22.15.33':
     resolution: {integrity: sha512-wzoocdnnpSxZ+6CjW4ADCK1jVmd1S/J3ArNWfn8FDDQtRm8dkDg7TA+mvek2wNrfCgwuZxqEOiB9B1XCJ6+dbw==}
 
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
-
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.0.2:
-    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
-    engines: {node: '>= 18'}
-
-  mkdirp@3.0.1:
-    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
-    engines: {node: '>=10'}
-    hasBin: true
+  modern-tar@0.3.5:
+    resolution: {integrity: sha512-TIALaZ8AjtEHFOZj1wRreDfaobCybvzPkvevpup/XtKOha3TmJWSwrh0ghc/QwAdAtt6oqIN6z6eIlo+HbDnzg==}
+    engines: {node: '>=18.0.0'}
 
   prettier@3.6.0:
     resolution: {integrity: sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==}
     engines: {node: '>=14'}
     hasBin: true
-
-  tar@7.4.3:
-    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
-    engines: {node: '>=18'}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -65,43 +44,16 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
-
 snapshots:
-
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.2
 
   '@types/node@22.15.33':
     dependencies:
       undici-types: 6.21.0
 
-  chownr@3.0.0: {}
-
-  minipass@7.1.2: {}
-
-  minizlib@3.0.2:
-    dependencies:
-      minipass: 7.1.2
-
-  mkdirp@3.0.1: {}
+  modern-tar@0.3.5: {}
 
   prettier@3.6.0: {}
-
-  tar@7.4.3:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.2
-      minizlib: 3.0.2
-      mkdirp: 3.0.1
-      yallist: 5.0.0
 
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
-
-  yallist@5.0.0: {}

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,8 +2,9 @@ import fs from 'node:fs/promises'
 import fss from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { pipeline } from 'node:stream'
-import { promisify } from 'node:util'
+import { pipeline } from 'node:stream/promises'
+import { createGunzip } from 'node:zlib'
+import { unpackTar } from 'modern-tar/fs'
 import { DownloadFailedError, SubdirNotFoundError } from './errors.js'
 import { providers as builtinProviders } from './providers.js'
 
@@ -76,7 +77,7 @@ export async function download(url, filePath, options = {}) {
 
   await fs.mkdir(path.dirname(filePath), { recursive: true })
   const stream = fss.createWriteStream(filePath)
-  await promisify(pipeline)(response.body, stream)
+  await pipeline(response.body, stream)
 
   await fs.writeFile(infoPath, JSON.stringify(info), 'utf8')
 }
@@ -154,51 +155,40 @@ export async function extract(tarPath, extractPath, subdir) {
   // Create an empty directory here to make tar happy
   await fs.mkdir(extractPath, { recursive: true })
 
-  // Workaround for Bun bug on Windows
-  // See https://github.com/oven-sh/bun/issues/12696
-  const needWorkaround =
-    // @ts-expect-error: TS doesn't know about the global Bun.
-    typeof Bun !== 'undefined' && process.platform === 'win32'
-  const originalFakePlatform = process.env.__FAKE_PLATFORM__
+  const readStream = fss.createReadStream(tarPath)
+  const unpackStream = unpackTar(extractPath, {
+    filter(entry) {
+      const path = entry.name.split('/').slice(1).join('/')
 
-  if (needWorkaround) {
-    process.env.__FAKE_PLATFORM__ = 'linux'
-  }
+      // Skip the root directory
+      if (path === '') {
+        return false
+      }
 
-  // We dynamically import `tar` to make sure the platform is faked if needed.
-  const { extract: _extract } = await import('tar')
+      if (!subdir) {
+        return true
+      }
 
-  if (needWorkaround) {
-    // Cleaning up the fake platform.
-    if (originalFakePlatform != null) {
-      process.env.__FAKE_PLATFORM__ = originalFakePlatform
-    } else {
-      delete process.env.__FAKE_PLATFORM__
-    }
-  }
-
-  await _extract({
-    file: tarPath,
-    cwd: extractPath,
-    // `chmod` and `processUmask` are set for compatibility with v6 behaviour,
-    // however it also seems useful to enable these anyways in case the downloaded
-    // templates have executable bash scripts or similar.
-    chmod: true,
-    processUmask: 0o22,
-    onReadEntry(entry) {
-      entry.path = entry.path.split('/').splice(1).join('/')
-      if (subdir) {
-        if (entry.path.startsWith(subdir)) {
-          // Rewrite path
-          entry.path = entry.path.slice(subdir.length - 1)
-          subdirFound = true
-        } else {
-          // Skip
-          entry.path = ''
-        }
+      if (path.startsWith(subdir)) {
+        subdirFound = true
+        return true
+      } else {
+        return false
       }
     },
+    map(entry) {
+      let path = entry.name.split('/').slice(1).join('/')
+
+      if (subdir) {
+        path = path.slice(subdir.length)
+      }
+
+      entry.name = path
+      return entry
+    },
   })
+
+  await pipeline(readStream, createGunzip(), unpackStream)
 
   if (subdir && !subdirFound) {
     // Clean up as it should be empty


### PR DESCRIPTION
## Overview

This re-reverts #8 and introduces `modern-tar` again with a [new release](https://github.com/ayuhito/modern-tar/releases/tag/v0.3.5). It's also a [tiny bit smaller in bundle size](https://bundlephobia.com/package/modern-tar@0.3.5).

The root cause seemed to stem from a race condition that only becomes very obvious via `npx` (slow I/O probably?). TAR marks the end of file with two blocks of zeroed data. Since we do not want to write the EOF data, the file stream might get closed a tick early, but the TAR decoder stream would still be processing leading to the original error.

### Reproductions

I added a bunch of tests to try to recreate this in the `modern-tar` repo and prevent regressions. I've also added some test `pkg.pr.new` that you can test yourself to reproduce the bug and fix:

Old buggy version (with some debug logs): `npx https://pkg.pr.new/ayuhito/astro/create-astro@e9c67bc`
New version: `https://pkg.pr.new/ayuhito/astro/create-astro@880e84b`

Running `create-astro.mjs` locally does not reproduce the bug 😔 